### PR TITLE
Fix compile ERROR, signed-interest.c:(.text+0x23f): undefined reference to `NDN_LOG_…

### DIFF
--- a/encode/signed-interest.c
+++ b/encode/signed-interest.c
@@ -13,6 +13,7 @@
 #include "../security/ndn-lite-hmac.h"
 #include "../security/ndn-lite-sha.h"
 #include "../security/ndn-lite-ecc.h"
+#include "../util/logger.h"
 
 /************************************************************/
 /*  Helper functions for Signed Interest APIs               */


### PR DESCRIPTION
From https://github.com/named-data-iot/ndn-iot-package-over-posix
$ mkdir build
$ cd build
$ cmake -DCMAKE_BUILD_TYPE=Release ..
$ make -j2
==> signed-interest.c:(.text+0x23f): undefined reference to `NDN_LOG_DEBUG' Error